### PR TITLE
Allow secrets to be in config instead of on filesystem

### DIFF
--- a/src/Common/CommonErrorMessages.Designer.cs
+++ b/src/Common/CommonErrorMessages.Designer.cs
@@ -104,7 +104,15 @@ namespace Google.Api.Ads.Common {
                 return ResourceManager.GetString("FailedToLoadJsonSecretsFile", resourceCulture);
             }
         }
-        
+
+        internal static string FailedToLoadJsonSecrets
+        {
+            get
+            {
+                return ResourceManager.GetString("FailedToLoadJsonSecrets", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Failed to parse response from server. See inner exception for more details..
         /// </summary>

--- a/src/Common/CommonErrorMessages.resx
+++ b/src/Common/CommonErrorMessages.resx
@@ -137,6 +137,10 @@
     <value>Failed to load JSON secrets file for service account configuration. See inner exception for details.</value>
     <comment>Used by AppConfigBase class when trying to load various settings from the JSON secrets file when using OAuth2 service account flow.</comment>
   </data>
+  <data name="FailedToLoadJsonSecrets" xml:space="preserve">
+    <value>Failed to load JSON secrets for service account configuration. See inner exception for details.</value>
+    <comment>Used by AppConfigBase class when trying to load various settings from the JSON secrets when using OAuth2 service account flow.</comment>
+  </data>
   <data name="FailedToParseAuthTokenException" xml:space="preserve">
     <value>Failed to parse response from server. See inner exception for more details.</value>
     <comment>Used as default error message when auth token error parsing fails.</comment>

--- a/src/Common/Lib/AppConfig.cs
+++ b/src/Common/Lib/AppConfig.cs
@@ -89,6 +89,11 @@ namespace Google.Api.Ads.Common.Lib
         string OAuth2SecretsJsonPath { get; set; }
 
         /// <summary>
+        /// contents
+        /// </summary>
+        string OAuth2SecretsJson { get; set; }
+
+        /// <summary>
         /// Gets the OAuth2 private key for service account flow.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
This PR adds support for being able to load secrets directly from app config (and therefore, environment vars in dotnet core) via a key named `OAuth2SecretsJson` instead of having to use `OAuth2SecretsJsonPath`. 

This PR is just to see the feasibility of being able to merge this because it would be super useful to us (and seemingly [others](https://github.com/googleads/googleads-dotnet-lib/issues/255)) if it was merged.  We can't move over to the new REST API because it doesn't have a ForecastService endpoint yet.